### PR TITLE
v0.2.7: fix series matching globbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.2.7](https://github.com/djdembeck/Audnexus.bundle/compare/v0.2.6...v0.2.7) (2022-01-11)
+
+
+### Bug Fixes
+
+* **album-search:** :zap: Multiply title score deduction by 2 to improve/fix [#9](https://github.com/djdembeck/Audnexus.bundle/issues/9) ([76502e9](https://github.com/djdembeck/Audnexus.bundle/commit/76502e9a50b6fb5453ad64389e4d27275916cc5c))
+
 ### [0.2.6](https://github.com/djdembeck/Audnexus.bundle/compare/v0.2.5...v0.2.6) (2021-11-24)
 
 

--- a/Contents/Code/_version.py
+++ b/Contents/Code/_version.py
@@ -1,1 +1,1 @@
-version = "0.2.6"
+version = "0.2.7"

--- a/Contents/Code/search_tools.py
+++ b/Contents/Code/search_tools.py
@@ -475,7 +475,7 @@ class ScoreTool:
         album_score = self.calculate_score(
             self.reduce_string(scorebase1),
             self.reduce_string(scorebase2)
-        )
+        ) * 2
         log.debug("Score deduction from album: " + str(album_score))
         return album_score
 


### PR DESCRIPTION
### [0.2.7](https://github.com/djdembeck/Audnexus.bundle/compare/v0.2.6...v0.2.7) (2022-01-11)


### Bug Fixes

* **album-search:** :zap: Multiply title score deduction by 2 to improve/fix [#9](https://github.com/djdembeck/Audnexus.bundle/issues/9) ([76502e9](https://github.com/djdembeck/Audnexus.bundle/commit/76502e9a50b6fb5453ad64389e4d27275916cc5c))