### PR TITLE
v0.2.8: handle empty album/artist file metadata fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.2.8](https://github.com/djdembeck/Audnexus.bundle/compare/v0.2.7...v0.2.8) (2022-01-24)
+
+
+### Bug Fixes
+
+* **album-search:** :bug: handle empty album/artist file metadata fields. fixes [#33](https://github.com/djdembeck/Audnexus.bundle/issues/33) ([dfba017](https://github.com/djdembeck/Audnexus.bundle/commit/dfba0179d5128b0064eeb52cc5021ec428cd13db))
+
 ### [0.2.7](https://github.com/djdembeck/Audnexus.bundle/compare/v0.2.6...v0.2.7) (2022-01-11)
 
 

--- a/Contents/Code/search_tools.py
+++ b/Contents/Code/search_tools.py
@@ -471,6 +471,9 @@ class ScoreTool:
             Score is calculated with LevenshteinDistance
         """
         scorebase1 = self.helper.media.album
+        if not scorebase1:
+            log.error('No album title found in file metadata')
+            return 50
         scorebase2 = title.encode('utf-8')
         album_score = self.calculate_score(
             self.reduce_string(scorebase1),
@@ -486,6 +489,9 @@ class ScoreTool:
         """
         if self.helper.media.artist:
             scorebase3 = self.helper.media.artist
+            if not scorebase3:
+                log.warn('No artist found in file metadata')
+                return 20
             scorebase4 = author
             author_score = self.calculate_score(
                 self.reduce_string(scorebase3),


### PR DESCRIPTION
### [0.2.8](https://github.com/djdembeck/Audnexus.bundle/compare/v0.2.7...v0.2.8) (2022-01-24)


### Bug Fixes

* **album-search:** :bug: handle empty album/artist file metadata fields. fixes [#33](https://github.com/djdembeck/Audnexus.bundle/issues/33) ([dfba017](https://github.com/djdembeck/Audnexus.bundle/commit/dfba0179d5128b0064eeb52cc5021ec428cd13db))