### PR TITLE
Detect ASINs in file path

### DIFF
--- a/Contents/Code/search_tools.py
+++ b/Contents/Code/search_tools.py
@@ -8,6 +8,8 @@ import urllib
 log = Logging()
 
 asin_regex = '[0-9A-Z]{10}'
+# asin preceded by '#' (url encoded)
+asin_path_regex = '%23([0-9A-Z]{10})[^\w]'
 
 
 class AlbumSearchTool:
@@ -166,17 +168,23 @@ class AlbumSearchTool:
             'normalizedName = %s', normalizedName
         )
 
-        # Chop off "unabridged"
-        normalizedName = re.sub(
-            r"[\(\[].*?[\)\]]", "", normalizedName
-        )
-        log.debug(
-            'chopping bracketed text = %s', normalizedName
-        )
-        normalizedName = normalizedName.strip()
-        log.debug(
-            'normalizedName stripped = %s', normalizedName
-        )
+        # Only use name if no ASIN is found in file path
+        match_asin = re.search(asin_path_regex, self.media.filename)
+        if (match_asin):
+            normalizedName = match_asin.group(1)
+            log.debug('detected ASIN in file path: %s', normalizedName)
+        else:
+            # Chop off "unabridged"
+            normalizedName = re.sub(
+                r"[\(\[].*?[\)\]]", "", normalizedName
+            )
+            log.debug(
+                'chopping bracketed text = %s', normalizedName
+            )
+            normalizedName = normalizedName.strip()
+            log.debug(
+                'normalizedName stripped = %s', normalizedName
+            )
 
         log.separator(
             msg=(

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ NOTE: Data is currently only available for the US region.
 
 - Plex Media Server `v1.24.4.5081` or greater.
 - `git` installed on system, as this is the preferred method of installing/updating the agent. You can also extract the zip instead.
-- Files are expected to be in/tested with common audiobook [file structure](https://support.plex.tv/articles/200265296-adding-music-media-from-folders/) and tags, specifically from either [Bragi Books](https://github.com/djdembeck/bragibooks) or [Seanap's guide](https://github.com/seanap/Plex-Audiobook-Guide). In particular, you are expected to have the following structure: `Author Name/Book Name/Book Name: Subtitle.m4b` with `album` and `albumartist` tags. This is imperative for proper matching!
+- Files are expected to be in/tested with common audiobook [file structure](https://support.plex.tv/articles/200265296-adding-music-media-from-folders/) and tags, specifically from either [Bragi Books](https://github.com/djdembeck/bragibooks) or [Seanap's guide](https://github.com/seanap/Plex-Audiobook-Guide). In particular, you are expected to have the following structure: `Author Name/Book Name/Book Name: Subtitle.m4b` with `album` and `albumartist` tags. This is imperative for proper matching! You can also override the metadata search by including an Audible ASIN after a `#` in your path. For example: `Author Name/Book Name #B01234ABCD/Book Name: Subtitle.m4b`.
 
 ### Installing
 


### PR DESCRIPTION
Short-circuit album search if an ASIN is detected after a `#` in the album's file path. Made this for my own library but this might close #19 if I understand it right.

Could be good to also override the artist search if it's possible to get the right data using the album ASIN, but that's beyond my needs at the moment.