### PR TITLE
feat: Add a `simplify_title` option to the preferences

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -61,7 +61,7 @@ class AudiobookArtist(Agent.Artist):
             return
 
         search_helper.media.artist = String.StripDiacritics(
-            search_helper.media.artist
+                search_helper.media.artist
         )
 
         # Call search API
@@ -285,9 +285,9 @@ class AudiobookAlbum(Agent.Album):
                 )
             )
             log.info(
-                'Using quick match based on asin: '
-                '%s' % quick_match_asin
-            )
+                    'Using quick match based on asin: '
+                    '%s' % quick_match_asin
+                )
             return
 
         # Strip title of things like unabridged and spaces

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -61,7 +61,7 @@ class AudiobookArtist(Agent.Artist):
             return
 
         search_helper.media.artist = String.StripDiacritics(
-                search_helper.media.artist
+            search_helper.media.artist
         )
 
         # Call search API
@@ -285,9 +285,9 @@ class AudiobookAlbum(Agent.Album):
                 )
             )
             log.info(
-                    'Using quick match based on asin: '
-                    '%s' % quick_match_asin
-                )
+                'Using quick match based on asin: '
+                '%s' % quick_match_asin
+            )
             return
 
         # Strip title of things like unabridged and spaces
@@ -485,11 +485,27 @@ class AudiobookAlbum(Agent.Album):
             tagger.add_authors_to_moods()
         # Series.
         tagger.add_series_to_moods()
-        # Setup title + subtitle where available.
-        if helper.subtitle:
-            album_title = helper.title + ': ' + helper.subtitle
+
+        # If the `simplify_title` option is selected, don't append subtitle
+        # and remove extra endings on the title
+        if Prefs['simplify_title']:
+            # If the title ends with a series part, remove it
+            # works for "Book 1" and "Book One"
+            album_title = re.sub(
+                r", book [\w\s-]+\s*$", "", helper.title, flags=re.IGNORECASE)
+            # If the title ends with "unabridged"/"abridged", with or without parenthesis
+            # remove them; case insensitive
+            album_title = re.sub(r" *\(?(un)?abridged\)?$", "",
+                                 album_title, flags=re.IGNORECASE)
+
+            album_title = album_title.strip()
+
+        # If not simplifying title, setup title + subtitle where available.
         else:
-            album_title = helper.title
+            if helper.subtitle:
+                album_title = helper.title + ': ' + helper.subtitle
+            else:
+                album_title = helper.title
         # Title.
         if not helper.metadata.title or helper.force:
             helper.metadata.title = album_title

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -489,23 +489,11 @@ class AudiobookAlbum(Agent.Album):
         # If the `simplify_title` option is selected, don't append subtitle
         # and remove extra endings on the title
         if Prefs['simplify_title']:
-            # If the title ends with a series part, remove it
-            # works for "Book 1" and "Book One"
-            album_title = re.sub(
-                r", book [\w\s-]+\s*$", "", helper.title, flags=re.IGNORECASE)
-            # If the title ends with "unabridged"/"abridged", with or without parenthesis
-            # remove them; case insensitive
-            album_title = re.sub(r" *\(?(un)?abridged\)?$", "",
-                                 album_title, flags=re.IGNORECASE)
-
-            album_title = album_title.strip()
-
-        # If not simplifying title, setup title + subtitle where available.
+            album_title = helper.simplify_title()
+        elif helper.subtitle:
+            album_title = helper.title + ': ' + helper.subtitle
         else:
-            if helper.subtitle:
-                album_title = helper.title + ': ' + helper.subtitle
-            else:
-                album_title = helper.title
+            album_title = helper.title
         # Title.
         if not helper.metadata.title or helper.force:
             helper.metadata.title = album_title

--- a/Contents/Code/update_tools.py
+++ b/Contents/Code/update_tools.py
@@ -100,6 +100,21 @@ class AlbumUpdateTool:
 
         log.separator(log_level="info")
 
+    # Remove extra description text from the title
+    def simplify_title(self):
+        # If the title ends with a series part, remove it
+        # works for "Book 1" and "Book One"
+        album_title = re.sub(
+            r", book [\w\s-]+\s*$", "", self.title, flags=re.IGNORECASE)
+        # If the title ends with "unabridged"/"abridged", with or without parenthesis
+        # remove them; case insensitive
+        album_title = re.sub(r" *\(?(un)?abridged\)?$", "",
+                                album_title, flags=re.IGNORECASE)
+        # Trim any leading/trailing spaces just in case
+        album_title = album_title.strip()
+
+        return album_title
+
 
 class ArtistUpdateTool:
     UPDATE_URL = 'https://api.audnex.us/authors/'

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -14,6 +14,11 @@
 	"type": "bool",
 	"default": "true"
 },{
+	"id": "simplify_title",
+	"label": "Simplify the books' titles",
+	"type": "bool",
+	"default": "false"
+},{
 	"id": "logging_level",
 	"label": "Level of plugin logging: ",
 	"type": "enum",

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -15,7 +15,7 @@
 	"default": "true"
 },{
 	"id": "simplify_title",
-	"label": "Simplify the books' titles",
+	"label": "Simplify book titles (remove subtitle, series part, (un)abridged, etc.)",
 	"type": "bool",
 	"default": "false"
 },{


### PR DESCRIPTION
I've recently been trying to switch to using this Agent over the one from seanap, but it has a few things I want to change before I'd be willing to, as those things go against what I'm looking for data wise (one of those things being original publish date).  Of course, I don't expect all of my changes to get merged into the main Agent as they're specific to my preferences, but I figured I'd submit what I can if it doesn't conflict with what you have already. Besides that I'll probably just maintain my own fork with the rest of my changes that are specific to my preferences.

I know in [`v0.2.1`](https://github.com/djdembeck/Audnexus.bundle/pull/13) you added the subtitle to each book's title. As you mention in #10 you did so because the relevant part of the title is sometimes only in the subtitle.  As for whether or not this is true, I believe that Audible has been switching the titles on a lot of their books to include the meat of the title in the main title section for the book.  In my opinion, this leads to some very repetitive and overly long title fields when you also include the subtitle.  Even for [the example you give](https://www.audible.com/pd/Star-Wars-Audiobook/B002V0THFQ), the subtitle is now just a piece of the main title, and using the subtitle leads you to have `Death Troopers: Star Wars Legends: Death Troopers`.

I thought that the best way to handle this for people like me who want cleaner/more minimal looking titles would be to add an option for it, so as not to break the existing behavior.  This option would prevent the agent from appending the subtitle, and perform further simplification transformation on it to make it look as clean as possible.

The additional steps it takes are as follows:

1. Remove the ending of the title if it includes `, Book N`, indicating a part in a series (i.e. `Book 1` or `Book One`).  I don't think this part of the title looks appealing as its not part of the book's actual title, just something they use to further identify it.

I'll use a Harry Potter book as an example: https://www.audible.com/pd/Harry-Potter-and-the-Order-of-the-Phoenix-Book-5-Audiobook/B017V4NMX4

The title for this book is 

```
Harry Potter and the Order of the Phoenix, Book 5
```

and this setting would change it to 

```
Harry Potter and the Order of the Phoenix
```

I have found that Audible does this with decent frequency, and I use this transformation in my own app I shared with you.

2. Remove any `(Unabridged)` or `(Abridged)` text from the end of the title.  I'm not sure if you're already doing this at any point before this, so if this is unnecessary let me know.  I believe you're doing it before running a search and on the search results in order to match better, but I'm not sure if you're keeping it that way for the final title.  Regardless, I think this is a good change to keep the titles looking minimal.  Like I mention in the first transformation, this is not part of the book's title, just a way of describing it.

Let me know if this change works for you!  Overall I think its a nice option to have for those like me who want the title to look as clean and close to the original as possible.  Also definitely let me know if you want me to make any changes before it's good to go!

---

**EDIT:** Sorry, a couple unrelated code formatting changes slipped into this PR that were done by my editor's formatter, hopefully thats not a problem!