### PR TITLE
Workaround for default "Match" search results

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -272,6 +272,13 @@ class AudiobookAlbum(Agent.Album):
             search_helper.media.album
         )
 
+        #workaround for default search not getting results using Plex "Match" menu
+        #search_helper.media.album was "none", but search_helper.media.title was accurate
+        if not normalizedName or normalizedName == "None":
+            normalizedName = String.StripDiacritics(
+                search_helper.media.title
+            )
+
         # Check if we can quick match based on asin
         quick_match_asin = search_helper.check_for_asin()
         if quick_match_asin:


### PR DESCRIPTION
Default was searching for "None" if a book wasn't matched at all ("Match" instead of "Fix Match").  When using the "Match" context menu item on an album, the actual search_helper.media.album value was "None", not an album.  I treated this as an edge case instead of just changing it to search_helper.media.title directly.  So if the value is either null or "None", we use the media title, instead of the media album.