### PR TITLE
feat!: multi region

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -568,13 +568,16 @@ def make_request(url):
     num_retries = 4
     for x in range(0, num_retries):
         try:
-            make_request = HTTP.Request(url)
+            make_request = HTTP.Request(url, timeout=120, sleep=sleep_time)
             str_error = None
         except Exception as str_error:
             log.error("Failed http request attempt #" + x + ": " + url)
             log.error(str_error)
+        except SSLError as ssl_error:
+            log.error("Failed http request attempt #" + x + ": " + url)
+            log.error(ssl_error)
 
-        if str_error:
+        if str_error or ssl_error:
             sleep(sleep_time)
             sleep_time *= x
         else:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -51,7 +51,7 @@ class AudiobookArtist(Agent.Artist):
 
     def search(self, results, media, lang, manual):
         # Instantiate search helper
-        search_helper = ArtistSearchTool(lang, manual, media, results)
+        search_helper = ArtistSearchTool(lang, manual, media, Prefs, results)
 
         # Validate author name
         search_helper.validate_author_name()
@@ -61,7 +61,7 @@ class AudiobookArtist(Agent.Artist):
             return
 
         search_helper.media.artist = String.StripDiacritics(
-                search_helper.media.artist
+            search_helper.media.artist
         )
 
         # Call search API
@@ -120,7 +120,7 @@ class AudiobookArtist(Agent.Artist):
         )
 
         # Instantiate update helper
-        update_helper = ArtistUpdateTool(force, lang, media, metadata)
+        update_helper = ArtistUpdateTool(force, lang, media, metadata, Prefs)
 
         self.call_item_api(update_helper)
 
@@ -193,9 +193,8 @@ class AudiobookArtist(Agent.Artist):
             Calls Audnexus API to get author details,
             then calls helper to parse those details.
         """
-        request = str(make_request(
-            helper.UPDATE_URL + helper.metadata.id
-        ))
+        update_url = helper.build_url()
+        request = str(make_request(update_url))
         response = json_decode(request)
         helper.parse_api_response(response)
 
@@ -259,7 +258,7 @@ class AudiobookAlbum(Agent.Album):
 
     def search(self, results, media, lang, manual):
         # Instantiate search helper
-        search_helper = AlbumSearchTool(lang, manual, media, results)
+        search_helper = AlbumSearchTool(lang, manual, media, Prefs, results)
 
         pre_check = search_helper.pre_search_logging()
         # Purposefully terminate search if it's bad
@@ -291,9 +290,9 @@ class AudiobookAlbum(Agent.Album):
                 )
             )
             log.info(
-                    'Using quick match based on asin: '
-                    '%s' % quick_match_asin
-                )
+                'Using quick match based on asin: '
+                '%s' % quick_match_asin
+            )
             return
 
         # Strip title of things like unabridged and spaces
@@ -389,7 +388,7 @@ class AudiobookAlbum(Agent.Album):
         )
 
         # Instantiate update helper
-        update_helper = AlbumUpdateTool(force, lang, media, metadata)
+        update_helper = AlbumUpdateTool(force, lang, media, metadata, Prefs)
 
         self.call_item_api(update_helper)
 
@@ -467,9 +466,8 @@ class AudiobookAlbum(Agent.Album):
             Calls Audnexus API to get book details,
             then calls helper to parse those details.
         """
-        request = str(make_request(
-            helper.UPDATE_URL + helper.metadata.id
-        ))
+        update_url = helper.build_url()
+        request = str(make_request(update_url))
         response = json_decode(request)
         helper.parse_api_response(response)
 

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -51,7 +51,7 @@ class AudiobookArtist(Agent.Artist):
 
     def search(self, results, media, lang, manual):
         # Instantiate search helper
-        search_helper = ArtistSearchTool(lang, manual, media, Prefs, results)
+        search_helper = ArtistSearchTool('authors', lang, manual, media, Prefs, results)
 
         # Check if we can quick match based on asin
         quick_match_asin = search_helper.check_for_asin()
@@ -277,7 +277,7 @@ class AudiobookAlbum(Agent.Album):
 
     def search(self, results, media, lang, manual):
         # Instantiate search helper
-        search_helper = AlbumSearchTool(lang, manual, media, Prefs, results)
+        search_helper = AlbumSearchTool('books', lang, manual, media, Prefs, results)
 
         pre_check = search_helper.pre_search_logging()
         # Purposefully terminate search if it's bad

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -570,6 +570,7 @@ def make_request(url):
         try:
             make_request = HTTP.Request(url, timeout=90, sleep=sleep_time)
             str_error = None
+            ssl_error = None
         except Exception as str_error:
             log.error("Failed http request attempt #" + x + ": " + url)
             log.error(str_error)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -175,7 +175,8 @@ class AudiobookArtist(Agent.Artist):
         """
             Builds URL then calls API, returns the JSON to helper function.
         """
-        search_url = helper.build_url()
+        query = helper.build_search_args()
+        search_url = helper.build_url(query)
         request = str(make_request(search_url))
         response = json_decode(request)
         # When using asin match, put it into array
@@ -432,7 +433,8 @@ class AudiobookAlbum(Agent.Album):
         """
             Builds URL then calls API, returns the JSON to helper function.
         """
-        search_url = helper.build_url()
+        query = helper.build_search_args()
+        search_url = helper.build_url(query)
         request = str(make_request(search_url))
         response = json_decode(request)
         results_list = helper.parse_api_response(response)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -139,7 +139,7 @@ class AudiobookArtist(Agent.Artist):
         )
 
         # Instantiate update helper
-        update_helper = ArtistUpdateTool(force, lang, media, metadata, Prefs)
+        update_helper = ArtistUpdateTool('authors', force, lang, media, metadata, Prefs)
 
         self.call_item_api(update_helper)
 
@@ -256,7 +256,7 @@ class AudiobookArtist(Agent.Artist):
                     make_request(helper.thumb), sort_order=0
                 )
 
-        helper.writeInfo()
+        helper.log_update_metadata()
 
     def hasProxy(self):
         return Prefs['imageproxyurl'] is not None
@@ -394,7 +394,7 @@ class AudiobookAlbum(Agent.Album):
         )
 
         # Instantiate update helper
-        update_helper = AlbumUpdateTool(force, lang, media, metadata, Prefs)
+        update_helper = AlbumUpdateTool('books', force, lang, media, metadata, Prefs)
 
         self.call_item_api(update_helper)
 
@@ -540,7 +540,7 @@ class AudiobookAlbum(Agent.Album):
         if helper.rating:
             helper.metadata.rating = float(helper.rating) * 2
 
-        helper.writeInfo()
+        helper.log_update_metadata()
 
     def getDateFromString(self, string):
         try:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -564,11 +564,11 @@ def make_request(url):
         Makes and returns an HTTP request.
         Retries 4 times, increasing  time between each retry.
     """
-    sleep_time = 2
+    sleep_time = 1
     num_retries = 4
     for x in range(0, num_retries):
         try:
-            make_request = HTTP.Request(url, timeout=120, sleep=sleep_time)
+            make_request = HTTP.Request(url, timeout=90, sleep=sleep_time)
             str_error = None
         except Exception as str_error:
             log.error("Failed http request attempt #" + x + ": " + url)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -51,11 +51,12 @@ class AudiobookArtist(Agent.Artist):
 
     def search(self, results, media, lang, manual):
         # Instantiate search helper
-        search_helper = ArtistSearchTool('authors', lang, manual, media, Prefs, results)
+        search_helper = ArtistSearchTool(
+            'authors', lang, manual, media, Prefs, results)
 
         # Check if we can quick match based on asin
         quick_match_asin = search_helper.check_for_asin()
-        
+
         if quick_match_asin:
             results.Append(
                 MetadataSearchResult(
@@ -139,7 +140,8 @@ class AudiobookArtist(Agent.Artist):
         )
 
         # Instantiate update helper
-        update_helper = ArtistUpdateTool('authors', force, lang, media, metadata, Prefs)
+        update_helper = ArtistUpdateTool(
+            'authors', force, lang, media, metadata, Prefs)
 
         self.call_item_api(update_helper)
 
@@ -277,7 +279,8 @@ class AudiobookAlbum(Agent.Album):
 
     def search(self, results, media, lang, manual):
         # Instantiate search helper
-        search_helper = AlbumSearchTool('books', lang, manual, media, Prefs, results)
+        search_helper = AlbumSearchTool(
+            'books', lang, manual, media, Prefs, results)
 
         pre_check = search_helper.pre_search_logging()
         # Purposefully terminate search if it's bad
@@ -394,7 +397,8 @@ class AudiobookAlbum(Agent.Album):
         )
 
         # Instantiate update helper
-        update_helper = AlbumUpdateTool('books', force, lang, media, metadata, Prefs)
+        update_helper = AlbumUpdateTool(
+            'books', force, lang, media, metadata, Prefs)
 
         self.call_item_api(update_helper)
 

--- a/Contents/Code/_version.py
+++ b/Contents/Code/_version.py
@@ -1,1 +1,1 @@
-version = "0.4.1"
+version = "1.0.0"

--- a/Contents/Code/region_tools.py
+++ b/Contents/Code/region_tools.py
@@ -58,8 +58,11 @@ class RegionTool:
         region : str
             The region code to generate the URL for.
     """
-    def __init__(self, region: str, type: str, id: str = None, query: str = None):
+    def __init__(self, region, type, id = None, query = None):
         self.region = region
+        self.id = id
+        self.query = query
+        self.type = type
 
     def get_region(self):
         return self.region
@@ -75,7 +78,7 @@ class RegionTool:
         return available_regions[self.region]['TLD']
 
     def get_type_url(self):
-        return 'https://api.audnex.us' + '/' + type
+        return 'https://api.audnex.us' + '/' + self.type
 
     def get_search_url(self):
         return self.get_type_url() + self.get_region_query() + '&' + self.query
@@ -88,7 +91,7 @@ class RegionTool:
 
     # Audible
     def get_api_region_url(self):
-        return 'https://api.audible.{}/'.format(
+        return 'https://api.audible.{}'.format(
             available_regions[self.region]['TLD']
         )
 
@@ -99,4 +102,4 @@ class RegionTool:
         )
 
     def get_api_search_url(self):
-        return self.get_api_region_url() + '/' + '1.0/catalog/products' + '/' + self.get_api_params() + '&' + self.query
+        return self.get_api_region_url() + '/' + '1.0/catalog/products' + self.get_api_params() + '&' + self.query

--- a/Contents/Code/region_tools.py
+++ b/Contents/Code/region_tools.py
@@ -1,0 +1,102 @@
+available_regions = {
+    'au': {
+        'name': 'Australia',
+        'TLD': 'com.au',
+    },
+    'ca': {
+        'name': 'Canada',
+        'TLD': 'ca',
+    },
+    'de': {
+        'name': 'Germany',
+        'TLD': 'de',
+    },
+    'es': {
+        'name': 'Spain',
+        'TLD': 'es',
+    },
+    'fr': {
+        'name': 'France',
+        'TLD': 'fr',
+    },
+    'in': {
+        'name': 'India',
+        'TLD': 'in',
+    },
+    'it': {
+        'name': 'Italy',
+        'TLD': 'it',
+    },
+    'jp': {
+        'name': 'Japan',
+        'TLD': 'co.jp',
+    },
+    'us': {
+        'name': 'United States',
+        'TLD': 'com',
+    },
+    'uk': {
+        'name': 'United Kingdom',
+        'TLD': 'co.uk',
+    }
+}
+
+
+class RegionTool:
+    """
+        Used to generate URLs for different regions for both Audible and Audnexus.
+        
+        Parameters
+        ----------
+        type : str
+            The base type, e.g. 'authors' or 'books'
+        id : str, optional
+            The ASIN of the item to lookup. Can be None.
+        query : str, optional
+            Any additional query parameters to add to the URL. Can be None.
+            Must be pre-formatted for Audnexus, e.g. '&page=1&limit=10'
+        region : str
+            The region code to generate the URL for.
+    """
+    def __init__(self, region: str, type: str, id: str = None, query: str = None):
+        self.region = region
+
+    def get_region(self):
+        return self.region
+
+    def get_region_name(self):
+        return available_regions[self.region]['name']
+
+    # Audnexus
+    def get_region_query(self):
+        return '?region=' + self.region
+
+    def get_region_tld(self):
+        return available_regions[self.region]['TLD']
+
+    def get_type_url(self):
+        return 'https://api.audnex.us' + '/' + type
+
+    def get_search_url(self):
+        return self.get_type_url() + self.get_region_query() + '&' + self.query
+
+    def get_id_url(self):
+        return self.get_type_url() + '/' + self.id + self.get_region_query()
+
+    def get_id_url_with_query(self):
+        return self.get_type_url() + '/' + self.id + self.get_region_query() + '&' + self.query
+
+    # Audible
+    def get_api_region_url(self):
+        return 'https://api.audible.{}/'.format(
+            available_regions[self.region]['TLD']
+        )
+
+    def get_api_params(self):
+        return (
+            '?response_groups=contributors,product_desc,product_attrs'
+            '&num_results=25&products_sort_by=Relevance'
+        )
+
+    def get_api_search_url(self):
+        return self.get_api_region_url() + '/' + '1.0/catalog/products' + '/' + self.get_api_params() + '&' + self.query

--- a/Contents/Code/region_tools.py
+++ b/Contents/Code/region_tools.py
@@ -58,11 +58,11 @@ class RegionTool:
         region : str
             The region code to generate the URL for.
     """
-    def __init__(self, region, type, id = None, query = None):
+    def __init__(self, region, content_type, id = None, query = None):
         self.region = region
         self.id = id
         self.query = query
-        self.type = type
+        self.content_type = content_type
 
     def get_region(self):
         return self.region
@@ -77,17 +77,17 @@ class RegionTool:
     def get_region_tld(self):
         return available_regions[self.region]['TLD']
 
-    def get_type_url(self):
-        return 'https://api.audnex.us' + '/' + self.type
+    def get_content_type_url(self):
+        return 'https://api.audnex.us' + '/' + self.content_type
 
     def get_search_url(self):
-        return self.get_type_url() + self.get_region_query() + '&' + self.query
+        return self.get_content_type_url() + self.get_region_query() + '&' + self.query
 
     def get_id_url(self):
-        return self.get_type_url() + '/' + self.id + self.get_region_query()
+        return self.get_content_type_url() + '/' + self.id + self.get_region_query()
 
     def get_id_url_with_query(self):
-        return self.get_type_url() + '/' + self.id + self.get_region_query() + '&' + self.query
+        return self.get_content_type_url() + '/' + self.id + self.get_region_query() + '&' + self.query
 
     # Audible
     def get_api_region_url(self):

--- a/Contents/Code/region_tools.py
+++ b/Contents/Code/region_tools.py
@@ -45,7 +45,7 @@ available_regions = {
 class RegionTool:
     """
         Used to generate URLs for different regions for both Audible and Audnexus.
-        
+
         Parameters
         ----------
         type : str
@@ -58,7 +58,8 @@ class RegionTool:
         region : str
             The region code to generate the URL for.
     """
-    def __init__(self, region, content_type, id = None, query = None):
+
+    def __init__(self, region, content_type, id=None, query=None):
         self.region = region
         self.id = id
         self.query = query

--- a/Contents/Code/search_tools.py
+++ b/Contents/Code/search_tools.py
@@ -29,10 +29,23 @@ class SearchTool:
         # Default to album and use artist if no album
         manual_asin = self.media.album if self.media.album else self.media.artist
         manual_search_asin = self.search_asin(manual_asin)
+
         if filename_search_asin:
-            return filename_search_asin.group(0)
+            region = self.check_for_region(self.media.filename)
+            return filename_search_asin.group(0) + '_' + region
         elif manual_search_asin:
-            return manual_search_asin.group(0)
+            region = self.check_for_region(manual_asin)
+            return manual_search_asin.group(0) + '_' + region
+
+    # Check for region override
+    def check_for_region(self, search_title):
+        """
+            Overrides the search with a region.
+        """
+        match_region = self.search_region(search_title)
+        self.region_override = match_region.group(
+            0) if match_region else self.prefs['region']
+        log.info('Region Override: %s', self.region_override)
 
     def clear_contributor_text(self, string):
         contributor_regex = '.+?(?= -)'
@@ -81,10 +94,7 @@ class SearchTool:
         asin_search_title = self.media.artist
 
         # Region override
-        match_region = self.search_region(search_title)
-        self.region_override = match_region.group(
-            0) if match_region else self.prefs['region']
-        log.info('Region Override: %s', self.region_override)
+        self.region_override = self.region_override(search_title)
 
         # Normalize name
         if self.content_type == 'books':

--- a/Contents/Code/search_tools.py
+++ b/Contents/Code/search_tools.py
@@ -40,11 +40,15 @@ class SearchTool:
             return re.match(contributor_regex, string).group(0)
         return string
 
+    def log_search_url(self, search_url):
+        log.debug('Search URL: %s', search_url)
+
     def override_with_asin(self, match_asin, region=None):
         """
             Overrides the search with an ASIN.
         """
-        log.debug('Overriding' + ' ' + self.content_type + ' ' + 'search with ASIN')
+        log.debug('Overriding' + ' ' + self.content_type +
+                  ' ' + 'search with ASIN')
         asin = match_asin.group(0)
         # Param uses keyword for book and nothing for author
         type_param = '&keywords=' if self.content_type == 'books' else ''
@@ -64,7 +68,7 @@ class SearchTool:
             region_helper.id = asin
             search_url = region_helper.get_id_url()
 
-        log.debug('Search URL: %s', search_url)
+        self.log_search_url(search_url)
         return search_url
 
     def pre_process_title(self):
@@ -90,7 +94,7 @@ class SearchTool:
         # ASIN override
         match_asin = self.search_asin(asin_search_title)
         if match_asin:
-            return self.override_with_asin(match_asin, self.content_type, self.region_override)
+            return self.override_with_asin(match_asin, self.region_override)
 
     def search_asin(self, input):
         if input:
@@ -129,7 +133,7 @@ class AlbumSearchTool(SearchTool):
             content_type=self.content_type, query=(album_param + artist_param), region=self.region_override)
 
         search_url = region_helper.get_api_search_url()
-        log.debug('Search URL: %s', search_url)
+        self.log_search_url(search_url)
         return search_url
 
     def check_if_preorder(self, book_date):
@@ -168,7 +172,7 @@ class AlbumSearchTool(SearchTool):
         log.debug('Input Name: %s', input_name)
 
         # Remove brackets and text inside
-        name = re.sub(r'\[.*?\]', '', input_name)
+        name = re.sub(r'\[[^"]*\]', '', input_name)
         # Remove unwanted characters
         name = re.sub(r'[^\w\s]', '', name)
         # Remove unwanted words
@@ -291,7 +295,7 @@ class ArtistSearchTool(SearchTool):
 
         # Get search URL
         search_url = region_helper.get_search_url()
-        log.debug('Search URL: %s', search_url)
+        self.log_search_url(search_url)
         return search_url
 
     def cleanup_author_name(self, name):

--- a/Contents/Code/search_tools.py
+++ b/Contents/Code/search_tools.py
@@ -546,4 +546,4 @@ def clear_contributor_text(string):
 
 def search_asin(input):
     if input:
-        return re.search(asin_regex, input)
+        return re.search(asin_regex, urllib.unquote(input).decode('utf8'))

--- a/Contents/Code/search_tools.py
+++ b/Contents/Code/search_tools.py
@@ -202,11 +202,12 @@ class AlbumSearchTool(SearchTool):
             }:
                 search_results.append(
                     {
-                        'asin': item['asin'],
+                        'asin': item['asin'] + '_' + self.region_override,
                         'author': item['authors'],
                         'date': item['release_date'],
                         'language': item['language'],
                         'narrator': item['narrators'],
+                        'region': self.region_override,
                         'title': item['title'],
                     }
                 )
@@ -444,6 +445,7 @@ class ScoreTool:
         self.date = None
         self.language = None
         self.narrator = None
+        self.region = None
         self.title = None
         return self.score_result()
 
@@ -456,6 +458,7 @@ class ScoreTool:
         self.date = self.result_dict['date']
         self.language = self.result_dict['language'].title()
         self.narrator = self.result_dict['narrator'][0]['name']
+        self.region = self.result_dict['region']
         self.title = self.result_dict['title']
         return self.score_result()
 
@@ -505,6 +508,9 @@ class ScoreTool:
         if self.narrator:
             plex_score_dict['narrator'] = self.narrator
             data_to_log.append({'Narrator is': self.narrator})
+        if self.region:
+            plex_score_dict['region'] = self.region
+            data_to_log.append({'Region is': self.region})
         if score:
             plex_score_dict['score'] = score
             data_to_log.append({'Score is': str(score)})

--- a/Contents/Code/update_tools.py
+++ b/Contents/Code/update_tools.py
@@ -84,7 +84,6 @@ class UpdateTool:
         # Get the ASIN from the ID
         asin = self.metadata.id.split('_')[0]
         log.debug('Extracted ASIN from ID: ' + asin)
-        # return ASIN
         return asin
 
     def extract_region_from_id(self):

--- a/Contents/Code/update_tools.py
+++ b/Contents/Code/update_tools.py
@@ -1,5 +1,6 @@
 # Import internal tools
 from logging import Logging
+from region_tools import RegionTool
 import re
 
 # Setup logger
@@ -7,15 +8,14 @@ log = Logging()
 
 
 class AlbumUpdateTool:
-    UPDATE_URL = 'https://api.audnex.us/books/'
-
-    def __init__(self, force, lang, media, metadata):
+    def __init__(self, force, lang, media, metadata, prefs):
         self.date = None
         self.force = force
         self.genres = None
         self.lang = lang
         self.media = media
         self.metadata = metadata
+        self.prefs = prefs
         self.rating = None
         self.series = ''
         self.series2 = ''
@@ -23,6 +23,16 @@ class AlbumUpdateTool:
         self.thumb = ''
         self.volume = ''
         self.volume2 = ''
+
+    def build_url(self):
+        """
+            Builds the URL for the API request.
+        """
+        region_helper = RegionTool(region=self.prefs['region'], type='books', id=self.metadata.id)
+        
+        update_url = region_helper.get_id_url()
+        log.debug('Update URL: ' + update_url)
+        return update_url
 
     def parse_api_response(self, response):
         """
@@ -109,7 +119,7 @@ class AlbumUpdateTool:
         # If the title ends with "unabridged"/"abridged", with or without parenthesis
         # remove them; case insensitive
         album_title = re.sub(r" *\(?(un)?abridged\)?$", "",
-                                album_title, flags=re.IGNORECASE)
+                             album_title, flags=re.IGNORECASE)
         # Trim any leading/trailing spaces just in case
         album_title = album_title.strip()
 
@@ -117,16 +127,25 @@ class AlbumUpdateTool:
 
 
 class ArtistUpdateTool:
-    UPDATE_URL = 'https://api.audnex.us/authors/'
-
-    def __init__(self, force, lang, media, metadata):
+    def __init__(self, force, lang, media, metadata, prefs):
         self.date = None
         self.force = force
         self.genres = None
         self.lang = lang
         self.media = media
         self.metadata = metadata
+        self.prefs = prefs
         self.thumb = ''
+
+    def build_url(self):
+        """
+            Builds the URL for the API request.
+        """
+        region_helper = RegionTool(region=self.prefs['region'], type='authors', id=self.metadata.id)
+        
+        update_url = region_helper.get_id_url()
+        log.debug('Update URL: ' + update_url)
+        return update_url
 
     def parse_api_response(self, response):
         """

--- a/Contents/Code/update_tools.py
+++ b/Contents/Code/update_tools.py
@@ -28,7 +28,7 @@ class AlbumUpdateTool:
         """
             Builds the URL for the API request.
         """
-        region_helper = RegionTool(region=self.prefs['region'], type='books', id=self.metadata.id)
+        region_helper = RegionTool(region=self.prefs['region'], content_type='books', id=self.metadata.id)
         
         update_url = region_helper.get_id_url()
         log.debug('Update URL: ' + update_url)
@@ -141,7 +141,7 @@ class ArtistUpdateTool:
         """
             Builds the URL for the API request.
         """
-        region_helper = RegionTool(region=self.prefs['region'], type='authors', id=self.metadata.id)
+        region_helper = RegionTool(region=self.prefs['region'], content_type='authors', id=self.metadata.id)
         
         update_url = region_helper.get_id_url()
         log.debug('Update URL: ' + update_url)

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -1,32 +1,40 @@
-[{
-	"id": "keep_existing_genres",
-	"label": "Keep existing genres in place",
-	"type": "bool",
-	"default": "false"
-},{
-	"id": "store_author_as_mood",
-	"label": "Append authors as Mood tags",
-	"type": "bool",
-	"default": "true"
-},{
-	"id": "sort_author_by_last_name",
-	"label": "Sort artist by name [Last, First]",
-	"type": "bool",
-	"default": "true"
-},{
-	"id": "simplify_title",
-	"label": "Simplify book titles (remove subtitle, series part, (un)abridged, etc.)",
-	"type": "bool",
-	"default": "false"
-},{
-	"id": "logging_level",
-	"label": "Level of plugin logging: ",
-	"type": "enum",
-	"values": [
-		"DEBUG",
-		"INFO",
-		"WARN",
-		"ERROR"
-	],
-	"default": "WARN"
-}]
+[
+    {
+        "id": "region",
+        "label": "Default region to use when searching: ",
+        "type": "enum",
+        "values": ["au", "ca", "de", "es", "fr", "in", "it", "jp", "us", "uk"],
+        "default": "us"
+    },
+    {
+        "id": "keep_existing_genres",
+        "label": "Keep existing genres in place",
+        "type": "bool",
+        "default": "false"
+    },
+    {
+        "id": "store_author_as_mood",
+        "label": "Append authors as Mood tags",
+        "type": "bool",
+        "default": "true"
+    },
+    {
+        "id": "sort_author_by_last_name",
+        "label": "Sort artist by name [Last, First]",
+        "type": "bool",
+        "default": "true"
+    },
+    {
+        "id": "simplify_title",
+        "label": "Simplify book titles (remove subtitle, series part, (un)abridged, etc.)",
+        "type": "bool",
+        "default": "false"
+    },
+    {
+        "id": "logging_level",
+        "label": "Level of plugin logging: ",
+        "type": "enum",
+        "values": ["DEBUG", "INFO", "WARN", "ERROR"],
+        "default": "WARN"
+    }
+]


### PR DESCRIPTION
Couple of things to think about:

- [x] Should `metadata.id` use region codes? IE, `B017WPKX84` -> `uk-B017WPKX84`. This would be a breaking change.
- [x] Write a region override, similar to ASIN override.
- [x] The initial scan for `J.K. Rowling` failed because of timeouts. This might be an API specific issue that needs to be looked into, or add a timeout somehow to fetch requests.
- [x] Add author region override