### PR TITLE
Fix Author Moods Toggle

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -496,6 +496,10 @@ class AudiobookAlbum(Agent.Album):
         tagger.add_genres()
         # Narrators.
         tagger.add_narrators_to_styles()
+
+        # Moods:
+        if helper.force:
+            helper.metadata.moods.clear()
         # Authors.
         if Prefs['store_author_as_mood']:
             tagger.add_authors_to_moods()

--- a/Contents/Code/update_tools.py
+++ b/Contents/Code/update_tools.py
@@ -247,7 +247,6 @@ class TagTool:
         """
         contributor_regex = '.+?(?= -)'
         if not self.helper.metadata.moods or self.helper.force:
-            self.helper.metadata.moods.clear()
             # Loop through authors to check if it has contributor wording
             for author in self.helper.author:
                 if not re.match(contributor_regex, author['name']):


### PR DESCRIPTION
A while ago I ran into the issue where if you check the "Append authors as Mood tags" option when a library is first set up with this agent, books will be stuck with those tags even if this option is unchecked and the metadata is refreshed. As far as I can tell, this happens because the only place where the moods are cleared is inside the `add_authors_to_moods` function, which is never called if that option is not checked.

My attempt to fix this is based on moving the call to `helper.metadata.moods.clear()` before both of the mood tag setting functions, and only if `force` is set. I'm not an expert on these agents, but I assume `force` is `True` when a user triggers a manual refresh, can you confirm if that is the case?

I also removed the call to `clear()` the metadata inside the `add_authors_to_moods` function as it would only be called in this case `if not self.helper.metadata.moods`, meaning clearing wouldn't actually do anything? At least that's how I interpreted it.

To test this, you can just try switching a library back and forth between setting "Append authors as Mood tags" from checked to not checked and refreshing the metadata. Let me know if you'd like me to change anything to get this approved!