### PR TITLE
Square Author Images

### DIFF
--- a/Contents/Code/update_tools.py
+++ b/Contents/Code/update_tools.py
@@ -280,7 +280,10 @@ class AlbumUpdateTool(UpdateTool):
 class ArtistUpdateTool(UpdateTool):
     def get_square_image(self, image_url):
         """
-            Get square image from Audible
+            Get square author photos from Audible
+
+            Crop each portrait photo to a square centered at the top,
+            and crop each landscape photo to a square at the horizontal center
         """
         try:
             image_file_dl = urllib.urlopen(image_url)

--- a/Contents/Code/update_tools.py
+++ b/Contents/Code/update_tools.py
@@ -2,6 +2,9 @@
 from logging import Logging
 from region_tools import RegionTool
 import re
+import struct
+import urllib
+import os
 
 # Setup logger
 log = Logging()
@@ -275,6 +278,73 @@ class AlbumUpdateTool(UpdateTool):
 
 
 class ArtistUpdateTool(UpdateTool):
+    def get_square_image(self, image_url):
+        """
+            Get square image from Audible
+        """
+        try:
+            image_file_dl = urllib.urlopen(image_url)
+            image_file_dl_contents = image_file_dl.read()
+            image_file_dl.close()
+
+            image_file = os.tmpfile()
+            image_file.write(image_file_dl_contents)
+
+            image_file.seek(0)
+
+            head = image_file.read(24)
+            if len(head) != 24:
+                image_file.close()
+                return image_url
+
+            image_file.seek(0)  # Read 0xff next
+            size = 2
+            ftype = 0
+            while not 0xc0 <= ftype <= 0xcf:
+                image_file.seek(size, 1)
+                byte = image_file.read(1)
+                while ord(byte) == 0xff:
+                    byte = image_file.read(1)
+                ftype = ord(byte)
+                size = struct.unpack('>H', image_file.read(2))[0] - 2
+            # We are at a SOFn block
+            image_file.seek(1, 1)  # Skip `precision' byte.
+            height, width = struct.unpack('>HH', image_file.read(4))
+
+            image_file.close()
+
+            if (height > width):
+                # Return a portrait image centered at the top
+                w_str = str(width)
+                square_image_url = image_url.replace(
+                    '.jpg',
+                    '.__01_SX'+w_str+'_CR0,0,'+w_str+','+w_str+'__.jpg'
+                )
+                return square_image_url
+
+            if (width > height):
+                # Return a landscape image centered at the horizontal middle
+                h_str = str(height)
+                padding = str((width - height) / 2)
+                square_image_url = image_url.replace(
+                    '.jpg',
+                    '.__01_SY'+h_str+'_CR'+padding+',0,'+h_str+','+h_str+'__.jpg'
+                )
+                return square_image_url
+
+            return image_url
+
+        except Exception as err:
+            log.separator(
+                msg=(
+                    'Error getting square image for ' + self.media.title
+                ),
+                log_level="error"
+            )
+            log.error(err)
+        return image_url
+
+
     def parse_api_response(self, response):
         """
             Parses keys from API into helper variables if they exist.
@@ -291,7 +361,9 @@ class ArtistUpdateTool(UpdateTool):
         if 'name' in response:
             self.name = response['name']
         if 'image' in response:
-            self.thumb = response['image']
+            squared_image = self.get_square_image(response['image'])
+            log.debug('Square image: ' + squared_image)
+            self.thumb = squared_image
 
     def set_description(self):
         """


### PR DESCRIPTION
This is my PR for https://github.com/laxamentumtech/audnexus/issues/530

Like I mentioned in [this comment](https://github.com/laxamentumtech/audnexus/issues/530#issuecomment-1403069915), The centering actually has nothing to do with any sort of facial recognition, it just turned out that the photos in portrait layout look better when they're cropped to the top.  So instead of making a new custom option, I just set things up to crop each portrait image to a square centered at the top, and crop each landscape image at the horizontal center.

There is no real need for cropping the horizontal images, as Plex will do the same thing automatically, but I added it anyway in case you'd prefer images to be consistently coming back as square. If you don't want them cropped, I (or you) can just remove [L328-L336](https://github.com/djdembeck/Audnexus.bundle/pull/76/files#diff-228d237a5933d00ac00e8ebec667af23fa79953b3afa1faab1a08db3f2dfe06fR328-R336).

Let me know your thoughts!

---

Here is what my Authors looked like after running this new agent:

<img width="953" alt="image" src="https://user-images.githubusercontent.com/9214195/214708795-c03fd3d7-479e-4e5e-b7f9-89f4077f4604.png">

Compared to what they looked like before this change:

<img width="949" alt="image" src="https://user-images.githubusercontent.com/9214195/214390667-3c2c41aa-4a26-40b0-8782-0420f61d9af5.png">
