### PR TITLE
chore(release): v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.2.2](https://github.com/djdembeck/Audnexus.bundle/compare/v1.2.1...v1.2.2) (2023-03-19)
+
+
+### Bug Fixes
+
+* **album-search:** :bug: filename could be `None` when checking for asin ([d17cfef](https://github.com/djdembeck/Audnexus.bundle/commit/d17cfeff0a33f0083ecb7ac9489ae67ac21b4659)), closes [#92](https://github.com/djdembeck/Audnexus.bundle/issues/92)
+
 ### [1.2.1](https://github.com/djdembeck/Audnexus.bundle/compare/v1.2.0...v1.2.1) (2023-02-27)
 
 

--- a/Contents/Code/_version.py
+++ b/Contents/Code/_version.py
@@ -1,1 +1,1 @@
-version = "1.2.1"
+version = "1.2.2"

--- a/Contents/Code/search_tools.py
+++ b/Contents/Code/search_tools.py
@@ -44,7 +44,7 @@ class SearchTool:
             Checks filename (for books) and/or search query for ASIN to quick match.
         """
         # Check filename for ASIN if content type is books
-        if self.content_type == 'books':
+        if self.media.filename and self.content_type == 'books':
             # Provide a plain filename for ASIN search
             filename_unquoted = urllib.unquote(
                 self.media.filename).decode('utf8')


### PR DESCRIPTION
### [1.2.2](https://github.com/djdembeck/Audnexus.bundle/compare/v1.2.1...v1.2.2) (2023-03-19)


### Bug Fixes

* **album-search:** :bug: filename could be `None` when checking for asin ([d17cfef](https://github.com/djdembeck/Audnexus.bundle/commit/d17cfeff0a33f0083ecb7ac9489ae67ac21b4659)), closes [#92](https://github.com/djdembeck/Audnexus.bundle/issues/92)
