### PR TITLE
Update the link to the collections guide in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,4 +172,4 @@ There are a few tricks to know about using fix match for books and authors:
 - Sorted by Series number and then book title.
 
 **This agent cannot create collections for your series'. 
-If you would like to set up automatic collections for book series', you can do so with the guide here: [Audnexus+Plex-Meta-Manager: Audiobook Series Collections](https://github.com/book-tools/audnexus-pmm-series)**
+If you would like to set up automatic collections for book series', you can do so with the guide here: [Audnexus + Kometa: Audiobook Series Collections](https://github.com/book-tools/audnexus-kometa-series)**


### PR DESCRIPTION
This PR just updates the link in the README that you had included to my guide for creating auto collections with Plex-Meta-Manager. The name of the package actually recently changed to "Kometa", so I updated the repo name and the whole description to use the new name.

> ### What Happened to Plex Meta Manager?
> 
> On April 25th 2024, the Plex Meta Manager name was officially retired and replaced with Kometa. This change was essential to avoid a trademark issue with Plex.
> 
> If you are still using Plex Meta Manager and are unsure how to upgrade to Kometa, [click here to follow our guide](https://kometa.wiki/en/latest/kometa/guides/rebrand/)
> 
> — https://kometa.wiki/en/latest/

Along with that, I also updated all of the config so it's now using the most recent field versions, and tested that everything is working properly. I know it had gotten a bit out of date haha.

The link in your README currently still works properly, because it just redirects to the renamed repo's URL, but I figured it would still be better to keep the name of the package correct!