### PR TITLE
Add an option for simplifying series titles

### DIFF
--- a/Contents/Code/update_tools.py
+++ b/Contents/Code/update_tools.py
@@ -203,13 +203,17 @@ class AlbumUpdateTool(UpdateTool):
         if 'rating' in response:
             self.rating = response['rating']
         if 'seriesPrimary' in response:
-            self.series = response['seriesPrimary']['name']
+            self.series = self.simplify_series_title(
+                response['seriesPrimary']['name']
+            )
             if 'position' in response['seriesPrimary']:
                 self.volume = self.volume_prefix(
                     response['seriesPrimary']['position']
                 )
         if 'seriesSecondary' in response:
-            self.series2 = response['seriesSecondary']['name']
+            self.series2 = self.simplify_series_title(
+                response['seriesSecondary']['name']
+            )
             if 'position' in response['seriesSecondary']:
                 self.volume2 = self.volume_prefix(
                     response['seriesSecondary']['position']
@@ -346,6 +350,18 @@ class AlbumUpdateTool(UpdateTool):
         album_title = album_title.strip()
 
         return album_title
+    
+    def simplify_series_title(self, series_title):
+        """
+            Simplifies the series titles (series 1 and 2) by removing
+            the word "Series" from the end if it exists.
+        """
+        if self.prefs['simplify_series_title']:
+            if series_title:
+                simplified_series_title = re.sub(r" Series$", '', series_title, flags=re.IGNORECASE)
+                return simplified_series_title
+        return series_title
+
 
     def volume_prefix(self, string):
         """
@@ -534,7 +550,7 @@ class TagTool:
 
     def add_authors_to_moods(self):
         """
-            Adds authors to moods, except for cases in contibutors list.
+            Adds authors to moods, except for cases in contributors list.
         """
         contributor_regex = '.+?(?= -)'
         if not self.helper.metadata.moods or self.helper.force:

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -31,6 +31,12 @@
         "default": "false"
     },
     {
+        "id": "simplify_series_title",
+        "label": "Simplify series titles (remove ' Series' from the end if it exists)",
+        "type": "bool",
+        "default": "false"
+    },
+    {
         "id": "logging_level",
         "label": "Level of plugin logging: ",
         "type": "enum",


### PR DESCRIPTION
I use this bundle [in combination with Kometa](https://github.com/djdembeck/Audnexus.bundle/pull/125) for generating collections from my series, and I noticed an issue recently. For some reason, some books are getting tagged with "\<series title> Series" while others are getting tagged with just "\<series title>". This generally wouldn't matter as long as every book within a series gets tagged with the same value (all just series title or all series title series). However, I've found that in a few cases, sometimes books within the same series are getting tagged with both formats.

For example, for the series _Solo Leveling_, books 1-5 are getting tagged with "Series: Solo Leveling" while books 6-8 are getting tagged with "Series: Solo Leveling Series":

<img width="753" alt="Screenshot 2025-02-03 at 11 14 39 PM" src="https://github.com/user-attachments/assets/8a45cdc3-46bd-4980-99f8-bff147193ee3" />

<img width="750" alt="Screenshot 2025-02-03 at 11 14 31 PM" src="https://github.com/user-attachments/assets/965bfc81-378f-4c1d-986a-ed8e1120b88c" />

I found the same thing happening with one book in "The Beginning After the End"

<img width="752" alt="Screenshot 2025-02-03 at 11 15 16 PM" src="https://github.com/user-attachments/assets/80f4b1d5-8b2d-489c-9d64-293a7d50e9af" />

<img width="757" alt="Screenshot 2025-02-03 at 11 15 09 PM" src="https://github.com/user-attachments/assets/cd30b597-a2bf-44cb-b83c-740d9f0a5200" />

This is probably just an issue with Audible's tagging themselves, but I figured that an easy solution to this problem would just be to universally trim " Series" from the end of series titles. It really doesn't add any value to the name of the series, and by removing it, we can be more consistent with how books are tagged.

However, I didn't want to force this option on anyone, so I figured it would be a valid use case for a new preference in the agent settings:

<img width="758" alt="image" src="https://github.com/user-attachments/assets/36afa0ab-4e6b-42ca-bb29-10c557118145" />

---

I wasn't sure where the best place would be to put this logic (API response parsing from Audnexus, or inside the `add_series_to_moods` function or something like that), so I just added it to the API response parsing, as that should cover it in all use cases (moods + sort title). But let me know if you think it's not placed well.

And in general, let me know if this is a setting you think makes sense for this project! I'm using it in my local instance of the bundle either way, I just figured this could help other people.